### PR TITLE
Fix compatibility with MDL-86501

### DIFF
--- a/classes/datetime_limited.php
+++ b/classes/datetime_limited.php
@@ -140,9 +140,20 @@ class datetime_limited extends MoodleQuickForm_group {
 
         // The YUI2 calendar only supports the gregorian calendar type so only display the calendar image if this is being used.
         if ($calendartype->get_name() === 'gregorian') {
-            $image = $OUTPUT->pix_icon('i/calendar', get_string('calendar', 'calendar'), 'moodle');
-            $this->_elements[] = $this->createFormElement('link', 'calendar',
-                    null, '#', $image);
+            $image = $OUTPUT->pix_icon('i/calendar', '');
+            $this->_elements[] = $this->createFormElement(
+                'button',
+                'calendar',
+                $image,
+                [
+                    'type' => 'button',
+                    'title' => get_string('datepicker', 'calendar'),
+                    'aria-label' => get_string('datepicker', 'calendar'),
+                ],
+                [
+                    'customclassoverride' => 'btn-link btn-sm icon-no-margin',
+                ],
+            );
         }
 
         foreach ($this->_elements as $element){


### PR DESCRIPTION
## TL;DR

MDL-86501 changes the calendar button element, breaking any custom code that uses the previous method and throws a JS error, preventing other JS on the page from working.

https://moodle.atlassian.net/browse/MDL-86501

This patch implements the new format.