### PR TITLE
[#28] Make activity notification title configurable

### DIFF
--- a/classes/activity_notification_helper.php
+++ b/classes/activity_notification_helper.php
@@ -80,11 +80,14 @@ class activity_notification_helper {
 
         [$mod, $description] = $data;
 
+        $notificationtitle = get_config('local_submissionrestrict', 'activitynotificationtitle')
+            ?: get_string('activitynotificationtitle', 'local_submissionrestrict');
+
         $notification = new \core\output\notification(
             format_text($description, FORMAT_PLAIN),
             \core\output\notification::NOTIFY_INFO,
             true,
-            get_string('activitynotificationtitle', 'local_submissionrestrict'),
+            $notificationtitle,
         );
         $html = $PAGE->get_renderer('core')->render($notification);
 

--- a/lang/en/local_submissionrestrict.php
+++ b/lang/en/local_submissionrestrict.php
@@ -45,6 +45,8 @@ $string['report:modulename'] = 'Assignment name';
 $string['report:reason'] = 'Reason for override';
 $string['report:time'] = 'New time';
 $string['report:title'] = 'Submission overrides report';
+$string['settings:activitynotificationtitle'] = 'Activity notification title';
+$string['settings:activitynotificationtitle_desc'] = 'The title displayed on the notification banner shown to students on the activity view page when a non-standard deadline reason is set. If left blank, the default title will be used.';
 $string['settings:reasons'] = 'Reasons for overriding';
 $string['settings:reasons_desc'] = 'A list of reasons for overriding available timeslots. One reason per line.
 To display a description to students on the activity view page, append <strong>::</strong> followed by the description text. Example:<br>

--- a/settings.php
+++ b/settings.php
@@ -33,6 +33,14 @@ if ($hassiteconfig && $ADMIN->locate('localplugins')) {
         get_string('pluginname', 'local_submissionrestrict')
     );
 
+    $settings->add(new admin_setting_configtext(
+        'local_submissionrestrict/activitynotificationtitle',
+        get_string('settings:activitynotificationtitle', 'local_submissionrestrict'),
+        get_string('settings:activitynotificationtitle_desc', 'local_submissionrestrict'),
+        get_string('activitynotificationtitle', 'local_submissionrestrict'),
+        PARAM_TEXT
+    ));
+
     foreach (mod_manager::get_mods() as $mod) {
         $mod->add_settings($settings);
     }

--- a/version.php
+++ b/version.php
@@ -26,8 +26,8 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'local_submissionrestrict';
-$plugin->version = 2026041000;
-$plugin->release = 2026041000;
+$plugin->version = 2026041300;
+$plugin->release = 2026041300;
 $plugin->requires = 2024100700;
-$plugin->supported = [405, 405];  // Available as of Moodle 4.5.0 or later.
+$plugin->supported = [405, 405];
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
Fixes #28 

# Summary
Previously the notification banner title ("**Reason for non-standard deadline**") shown to students/staff on the activity view page was hard-coded to a lang string. This change makes it configurable via the admin settings page.

# Testing Instructions
1. Navigate to **_Site administration > Plugins > Local plugins > Submission restrictions_**
2. Confirm the new **Activity notification title** field appears, pre-filled with **Reason for non-standard deadline**
3. Change the title to something custom (e.g. Assessment deadline info) and save changes
4. Navigate to the activity view page that has a submission restriction set
5. Confirm the banner now shows the custom title